### PR TITLE
perf: add Caffeine response caching to student and attendance service

### DIFF
--- a/attendance-service/pom.xml
+++ b/attendance-service/pom.xml
@@ -96,6 +96,14 @@
 			<groupId>io.opentelemetry</groupId>
 			<artifactId>opentelemetry-exporter-logging</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>com.github.ben-manes.caffeine</groupId>
+			<artifactId>caffeine</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-cache</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/attendance-service/src/main/java/com/studenttracking/attendanceservice/AttendanceServiceApplication.java
+++ b/attendance-service/src/main/java/com/studenttracking/attendanceservice/AttendanceServiceApplication.java
@@ -2,8 +2,10 @@ package com.studenttracking.attendanceservice;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 
 @SpringBootApplication
+@EnableCaching
 public class AttendanceServiceApplication {
 
     public static void main(String[] args) {

--- a/attendance-service/src/main/java/com/studenttracking/attendanceservice/service/AttendanceService.java
+++ b/attendance-service/src/main/java/com/studenttracking/attendanceservice/service/AttendanceService.java
@@ -13,7 +13,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.util.*;
-
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
 @Service
 @RequiredArgsConstructor
 public class AttendanceService {
@@ -21,6 +22,7 @@ public class AttendanceService {
     private final AttendanceRepository attendanceRepository;
     private final NotificationClient notificationClient;
 
+    @CacheEvict(value = {"attendanceByStudent", "attendanceByClassDate", "attendancePercentage"}, allEntries = true)
     public Attendance markAttendance(AttendanceRequest request) {
 
         attendanceRepository.findByStudentIdAndClassIdAndDate(
@@ -43,15 +45,6 @@ public class AttendanceService {
 
         Attendance saved = attendanceRepository.save(attendance);
 
-        // Trigger SMS if student is ABSENT
-		/*
-		 * if (saved.getStatus() == AttendanceStatus.ABSENT) { if
-		 * (request.getPhoneNumber() != null && !request.getPhoneNumber().isEmpty()) {
-		 * notificationClient.sendAbsenceSms( request.getStudentId(),
-		 * request.getPhoneNumber(), request.getStudentName() != null ?
-		 * request.getStudentName() : "Student", request.getDate().toString() ); } }
-		 */
-        
         if (saved.getStatus() == AttendanceStatus.ABSENT) {
             if (request.getPhoneNumber() != null
                     && !request.getPhoneNumber().isEmpty()) {
@@ -70,6 +63,7 @@ public class AttendanceService {
     }
 
     @Transactional
+    @CacheEvict(value = {"attendanceByStudent", "attendanceByClassDate", "attendancePercentage"}, allEntries = true)
     public List<Attendance> markBulkAttendance(BulkAttendanceRequest request) {
         List<Attendance> saved = new ArrayList<>();
 
@@ -115,10 +109,12 @@ public class AttendanceService {
     }
 
     // existing query methods stay the same
+    @Cacheable(value = "attendanceByStudent", key = "#studentId")
     public List<Attendance> getAttendanceByStudent(UUID studentId) {
         return attendanceRepository.findByStudentId(studentId);
     }
 
+    @Cacheable(value = "attendanceByClassDate", key = "#classId + '-' + #date")
     public List<Attendance> getAttendanceByClassAndDate(
             UUID classId, LocalDate date) {
         return attendanceRepository.findByClassIdAndDate(classId, date);
@@ -136,6 +132,7 @@ public class AttendanceService {
                 studentId, from, to);
     }
 
+    @Cacheable(value = "attendancePercentage", key = "#studentId + '-' + #classId")
     public Map<String, Object> getAttendancePercentage(
             UUID studentId, UUID classId) {
         long total = attendanceRepository

--- a/attendance-service/src/main/resources/application.yaml
+++ b/attendance-service/src/main/resources/application.yaml
@@ -13,6 +13,7 @@ management:
           - info
           - metrics
           - prometheus
+          - caches
   health:
     defaults:
       enabled: true
@@ -34,6 +35,10 @@ services:
 spring:
   application:
     name: attendance-service
+  cache:
+    type: caffeine
+    caffeine:
+      spec: maximumSize=500,expireAfterWrite=300s
   datasource:
     driver-class-name: org.postgresql.Driver
     hikari:

--- a/student-service/pom.xml
+++ b/student-service/pom.xml
@@ -95,6 +95,15 @@
 			<groupId>io.opentelemetry</groupId>
 			<artifactId>opentelemetry-exporter-logging</artifactId>
 		</dependency>
+
+		<dependency>
+			<groupId>com.github.ben-manes.caffeine</groupId>
+			<artifactId>caffeine</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-cache</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/student-service/src/main/java/com/studenttracking/studentservice/StudentServiceApplication.java
+++ b/student-service/src/main/java/com/studenttracking/studentservice/StudentServiceApplication.java
@@ -2,8 +2,10 @@ package com.studenttracking.studentservice;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 
 @SpringBootApplication
+@EnableCaching
 public class StudentServiceApplication {
 
     public static void main(String[] args) {

--- a/student-service/src/main/java/com/studenttracking/studentservice/service/StudentService.java
+++ b/student-service/src/main/java/com/studenttracking/studentservice/service/StudentService.java
@@ -11,7 +11,8 @@ import org.springframework.stereotype.Service;
 
 import java.util.List;
 import java.util.UUID;
-
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
 @Service
 @RequiredArgsConstructor
 public class StudentService {
@@ -35,20 +36,24 @@ public class StudentService {
         return studentRepository.findAll(pageable);
     }
 
+    @Cacheable(value = "studentById", key = "#id")
     public Student getStudentById(UUID id) {
         return studentRepository.findById(id)
                 .orElseThrow(() -> new RuntimeException("Student not found"));
     }
 
+    @Cacheable(value = "studentByUserId", key = "#userId")
     public Student getStudentByUserId(UUID userId) {
         return studentRepository.findByUserId(userId)
                 .orElseThrow(() -> new RuntimeException("Student not found"));
     }
 
+    @Cacheable(value = "studentsByClass", key = "#classId")
     public List<Student> getStudentsByClass(UUID classId) {
         return studentRepository.findByClassId(classId);
     }
 
+    @CacheEvict(value = {"studentById", "studentByUserId", "studentsByClass"}, allEntries = true)
     public Student updateStudent(UUID id, StudentRequest request) {
         Student existing = getStudentById(id);
         existing.setName(request.getName());
@@ -56,6 +61,7 @@ public class StudentService {
         return studentRepository.save(existing);
     }
 
+    @CacheEvict(value = {"studentById", "studentByUserId", "studentsByClass"}, allEntries = true)
     public void deleteStudent(UUID id) {
         studentRepository.deleteById(id);
     }

--- a/student-service/src/main/resources/application.yaml
+++ b/student-service/src/main/resources/application.yaml
@@ -13,6 +13,7 @@ management:
           - info
           - metrics
           - prometheus
+          - caches
   servlet:
     multipart:
       max-file-size: 10MB
@@ -35,6 +36,10 @@ services:
 spring:
   application:
     name: student-service
+  cache:
+    caffeine:
+      spec: maximumSize=500,expireAfterWrite=300s
+    type: caffeine
   datasource:
     driver-class-name: org.postgresql.Driver
     hikari:


### PR DESCRIPTION
Added Caffeine cache dependency, enabled caching with 500 max size and 5-minute TTL. Applied @Cacheable on read methods and @CacheEvict on write methods for student and attendance data.
fix: add spring-boot-starter-cache dependency for Caffeine caching

Closes #80